### PR TITLE
Use TLS Ingress because not using .greenpeace.org

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ job_environments:
     HELM_RELEASE: planet4-ummah
     WP_DB_NAME: planet4-ummah_wordpress_develop
     WP_STATELESS_BUCKET: planet4-ummah-stateless-develop
+    INGRESS_TLS: true
+    INGRESS_NOTTLS: false
   release_build_env: &release_build_env
     GOOGLE_PROJECT_ID: planet4-production
   release_environment: &release_environment
@@ -46,6 +48,8 @@ job_environments:
     HELM_RELEASE: planet4-ummah-release
     WP_DB_NAME: planet4-ummah_wordpress_release
     WP_STATELESS_BUCKET: planet4-ummah-stateless-release
+    INGRESS_TLS: true
+    INGRESS_NOTTLS: false
   production_environment: &production_environment
     APP_HOSTNAME: ummah4earth.org
     APP_HOSTPATH: 
@@ -57,6 +61,8 @@ job_environments:
     MIN_REPLICA_COUNT: 2
     WP_DB_NAME: planet4-ummah_wordpress_master
     WP_STATELESS_BUCKET: planet4-ummah-stateless
+    INGRESS_TLS: true
+    INGRESS_NOTTLS: false
 
 commands:
   approve_job:


### PR DESCRIPTION
Because Ummah4earth is not using greenpeace.org we need to generate certificates for this domain. Changing these parameters will deploy an ingress resource that will automatically generate certs for this domain.